### PR TITLE
Prevent changing HVAC mode when turning it off

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -252,9 +252,10 @@ class DaikinMadokaClimate(ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode):
         """Set HVAC mode."""
         try:
-            await self.controller.operation_mode.update(
-                OperationModeStatus(HA_MODE_TO_DAIKIN.get(hvac_mode))
-            )
+            if hvac_mode != HVAC_MODE_OFF:
+                await self.controller.operation_mode.update(
+                    OperationModeStatus(HA_MODE_TO_DAIKIN.get(hvac_mode))
+                )
             await self.controller.power_state.update(
                 PowerStateStatus(hvac_mode != HVAC_MODE_OFF)
             )


### PR DESCRIPTION
I observed that when turning an HVAC off in Home assistant, the corresponding Madoka controller turned off properly, but its mode switched to auto (because of the mapping present [here](https://github.com/mduran80/daikin_madoka/blob/main/climate.py#L50)).
This PR prevents this behaviour.