### PR TITLE
Update climate.py for the upcoming changes of HA core 2025.1

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -12,7 +12,6 @@ from pymadoka import (
     SetPointStatus,
 )
 from pymadoka.connection import ConnectionStatus
-
 from homeassistant.components.climate import ClimateEntity, HVACMode, HVACAction, ClimateEntityFeature
 from homeassistant.components.climate.const import (
     FAN_AUTO,
@@ -98,8 +97,12 @@ class DaikinMadokaClimate(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
-
+        return (
+          ClimateEntityFeature.TARGET_TEMPERATURE
+          | ClimateEntityFeature.FAN_MODE
+          | ClimateEntityFeature.TURN_ON
+          | ClimateEntityFeature.TURN_OFF
+        )
     @property
     def available(self):
         """Return the availability."""
@@ -369,4 +372,3 @@ class DaikinMadokaClimate(ClimateEntity):
             "sw_version": sw_version,
             "via_device": (DOMAIN, self.unique_id),
         }
-


### PR DESCRIPTION
Update the supported_features property of the DaikinMadokaClimate class to include the TURN_ON and TURN_OFF features, in addition to the existing TARGET_TEMPERATURE and FAN_MODE features.